### PR TITLE
Fix: ignore tokens should be set to -100, not -1

### DIFF
--- a/run.py
+++ b/run.py
@@ -345,7 +345,7 @@ def mask_tokens(inputs, tokenizer, mlm_probability=0.15):
     probability_matrix.masked_fill_(torch.tensor(labels == 0, dtype=torch.bool), value=0.0)
 
     masked_indices = torch.bernoulli(probability_matrix).bool()
-    labels[~masked_indices] = -1  # We only compute loss on masked tokens
+    labels[~masked_indices] = -100  # We only compute loss on masked tokens
 
     # 80% of the time, we replace masked input tokens with tokenizer.mask_token ([MASK])
     indices_replaced = torch.bernoulli(torch.full(labels.shape, 0.8)).bool() & masked_indices


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Correcting the value of unmasked indices in the target tensor in mask_tokens(). 
Currently, line 348 is: labels[~masked_indices] = -1
But, the value of -1 breaks the loss function. From BertForMaskedLM documentation: "Indices should be in [-100, 0, ..., config.vocab_size] ... Tokens with indices set to -100 are ignored (masked), the loss is only computed for the tokens with labels in [0, ..., config.vocab_size]"
This value constraint appears to hold in every version of the HuggingFace API which has documentation for BertForMaskedLM.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
